### PR TITLE
Fix variable type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -175,13 +175,13 @@ variable "env_raw" {
 
 variable "pod_security_context" {
   description = "Pod securityContext"
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
 variable "container_security_context" {
   description = "Container securityContext"
-  type        = map(any)
+  type        = any
   default     = {}
 }
 


### PR DESCRIPTION
Got this error when define security_context var as type `map(any)`:

```
│ Error: Invalid value for module argument
│
│   on ambassador.tf line 111, in module "ambassador":
│  111:   pod_security_context = {
│  112:     runAsUser = 8888
│  113:     seccompProfile = {
│  114:       type = "RuntimeDefault"
│  115:     }
│  116:   }
│
│ The given value is not suitable for child module variable
│ "pod_security_context" defined at
│ .terraform/modules/ambassador/variables.tf:176,1-32: all map elements must
│ have the same type.
╵
╷
│ Error: Invalid value for module argument
│
│   on ambassador.tf line 118, in module "ambassador":
│  118:   container_security_context = {
│  119:     allowPrivilegeEscalation = false
│  120:     seccompProfile = {
│  121:       type = "RuntimeDefault"
│  122:     }
│  123:   }
│
│ The given value is not suitable for child module variable
│ "container_security_context" defined at
│ .terraform/modules/ambassador/variables.tf:182,1-38: all map elements must
│ have the same type.
╵
ERRO[0011] 1 error occurred:
        * exit status 1
```